### PR TITLE
fix create user name combine bitween first_name and last_name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ test:
 	docker-compose -f local.yml run --rm api pytest
 
 test_with_printing_messages:
-	docker-compose -f local.yml run --rm api pytest -rP
+	docker-compose -f local.yml run --rm api pytest -v -rP
 
 clear_database:
 	docker-compose -f local.yml down --rmi all --volumes

--- a/tests/apis/users/test_user_update.py
+++ b/tests/apis/users/test_user_update.py
@@ -9,21 +9,23 @@ def test_user_update(api_client, user):
     api_client.force_authenticate(user)
     url = reverse(
         "user:user-detail",
-        args=[
+         args = [
             "me",
         ],
     )
     email = factory.Faker._get_faker().email()
-    # first_name = factory.Faker._get_faker().first_name()
-    # last_name = factory.Faker._get_faker().last_name()
+    first_name = factory.Faker._get_faker().first_name()
+    last_name = factory.Faker._get_faker().last_name()
     response = api_client.patch(
         url,
         data={
             "email": email,
-            "username": "test test",
+            "username": str(first_name)+"_"+str(last_name),
         },
     )
+    # print("First Name: ", first_name)
+    # print("Email: ", email)
     assert url == "/api/users/me/"
     assert response.status_code == status.HTTP_200_OK, response.content
     assert response.json()["email"] == email
-    assert response.json()["username"] == "test test"
+    assert response.json()["username"] == str(first_name)+"_"+str(last_name)


### PR DESCRIPTION
## What does this do?

fix username creation

## Tickets / Documentation

[REA-49](https://linear.app/reastation/issue/REA-49/as-an-operator-i-need-to-fix-the-patch-of-first-name-and-last-name-in)